### PR TITLE
Adds md5 checksum verification to downloads.

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1007,6 +1007,11 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
         except (KeyError, ValueError, TypeError):
             size = None
 
+        try:
+            content_md5 = info['Content-MD5']
+        except (KeyError, ValueError, TypeError):
+            content_md5 = None
+
         if size is not None:
             check_free_space_in_dir(gettempdir(), size)
             if cache:
@@ -1044,6 +1049,11 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
                             f"File was supposed to be {size} bytes but we "
                             f"only got {bytes_read} bytes. Download failed.",
                             content=None)
+                    if content_md5 is not None and content_md5 != hasher.hexdigest():
+                        raise urllib.error.URLError(
+                            f"Checksum of downloaded file does not match "
+                            f"checksum of file in server headers. "
+                            f"Download failed.")
                 except BaseException:
                     if os.path.exists(f.name):
                         try:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This adds md5 verification to file downloads using a request's "Content-MD5" header response value (if that header value exists) and falling back to the old "Content-Length" checking if it does not. It adds three new test cases that hopefully catch any problems introduced by this. This is partly inspired by [download verification](https://github.com/jehturner/ndmapper/blob/7c2b48a5b8dfd37c21b3f4c691720eefddd42cb9/ndmapper/services.py#L301) in James Turner's NDMapper for Gemini file downloads.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1719 when combined with https://github.com/Nat1405/astroquery/pull/1.

